### PR TITLE
Compiletime assertion and DBG_VAR macro

### DIFF
--- a/glass/src/debug.h
+++ b/glass/src/debug.h
@@ -4,3 +4,17 @@
 #ifdef __DEBUG__
 #define DEBUG_PRINT(x, y) serial_terminal()->put##y(x);
 #endif
+
+#ifndef NDEBUG
+/*dont let the compiler optimize out my variable, please!*/
+#define DBG_VAR volatile
+/*static_assert is valid in C11 through gnu C extensions which are used by default in clang.*/
+#define GLASS_ASSERT(cond) static_assert(cond, "Compiletime test failed");
+#warning "file" __FILE__ "is compiling with compiletime and runtime debugging features enabled! Expect lower performance".
+
+#else
+
+#define DBG_VAR /*a comment.*/
+#define GLASS_ASSERT(cond) /*another comment*/
+
+#endif


### PR DESCRIPTION
makes for more expressive code than putting "volatile" everywhere.
You should only use volatile when you need it.